### PR TITLE
Vercel 자동 배포 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+
+      - name: creates output
+        run: sh ./build.sh
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: 'output'
+          destination-github-username: JANGSEYEONG
+          destination-repository-name: COMTAM
+          user-email: ${{ secrets.OFFICIAL_ACCOUNT_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./COOMTAM_FE/* ./output
+cp -R ./output ./COOMTAM_FE/


### PR DESCRIPTION
## ❗ Issue Number or Link

- #1 

## 🔎 작업 내용(필수)

Vercel의 Organization Repository 연동은 체험 기간 이후 유료 결제를 해야하는 문제가 있습니다.
개인 플랜은 무료기에, Organization Repository의 main branch에 push 이벤트가 발생할 경우 개인 Repository의 main branch에도 자동 push가 되게 연동하여 Vercel에 자동 배포가 되도록 했습니다.

- Organization Secret key 생성
- build.sh 생성 : action flow 시 실행할 명령어
- .github/workflows/deploy.yml 생성 : develop main에 push 시 개인 계정 repo로 자동 push ([제 계정의 레포지토리로 만들었습니다. ](https://github.com/JANGSEYEONG/COMTAM))


## 🖼️ 작업 화면 캡처(선택)

- 여기에 작성

## 📢 주의 및 리뷰 요청

- 여기에 작성

## 🔗 Reference

- https://vanilla-van-6e4.notion.site/vercel-47312c7c2a9c492dbdabc40c47489cfa
- https://velog.io/@rmaomina/organization-vercel-hobby-deploy
