### PR TITLE
FEAT: Button, DescriptionCard 컴포넌트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     ]
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "next": "14.1.0",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "tailwind-merge": "^2.5.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     ]
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "next": "14.1.0",
     "react": "^18",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Button from '@/components/common/Button';
+import DescriptionCard from '@/components/common/DescriptionCard';
 
 export default function Home() {
   return (
@@ -7,6 +8,7 @@ export default function Home() {
         카카오톡으로 문의하기
       </Button>
       <Button className="w-full">카카오톡으로 문의하기</Button>
+      <DescriptionCard title="모집기간" contents="상시" />
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,47 +1,12 @@
-import ArrowUpBlue from '../../public/assets/icons/ArrowUpBlue.svg';
-import WarningBlue from '../../public/assets/icons/WarningBlue.svg';
+import Button from '@/components/common/Button';
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen gap-6 p-24">
-      <div>
-        <h2>Pretendard Typography</h2>
-        <div className="flex gap-3">
-          <ArrowUpBlue className="w-3" />
-          <ArrowUpBlue className="w-4" />
-          <WarningBlue className="w-5" />
-        </div>
-        <hr />
-        <p className="pretandard-title-1">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-title-2">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-headline-1">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-headline-2">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-headline-3">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-subtitle-1">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-subtitle-2">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-subtitle-3">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-subtitle-5">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-body-l">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-body-1">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-body-2">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-body-3">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-body-5">코탐에서 함께 성장해요!</p>
-        <p className="pretandard-caption-1">코탐에서 함께 성장해요!</p>
-      </div>
-      <div>
-        <h2>Galmuri11 Typography</h2>
-        <hr />
-        <p className="galmuri11-headline-1">코탐에서 함께 성장해요!</p>
-        <p className="galmuri11-headline-2">코탐에서 함께 성장해요!</p>
-        <p className="galmuri11-headline-3">코탐에서 함께 성장해요!</p>
-        <p className="galmuri11-subtitle-1">코탐에서 함께 성장해요!</p>
-        <p className="galmuri11-body-l">코탐에서 함께 성장해요!</p>
-        <p className="galmuri11-body-m">코탐에서 함께 성장해요!</p>
-        <p className="galmuri11-body-1">코탐에서 함께 성장해요!</p>
-        <p className="galmuri11-body-2">코탐에서 함께 성장해요!</p>
-        <p className="galmuri11-body-3">코탐에서 함께 성장해요!</p>
-        <p className="galmuri11-body-5">코탐에서 함께 성장해요!</p>
-      </div>
+    <main className="min-h-screen w-screen gap-6 p-24">
+      <Button className="w-full" variant="blue">
+        카카오톡으로 문의하기
+      </Button>
+      <Button className="w-full">카카오톡으로 문의하기</Button>
     </main>
   );
 }

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,29 @@
+import { cn } from '@/lib/utils';
+import { cva, VariantProps } from 'class-variance-authority';
+import { forwardRef } from 'react';
+
+const buttonVariants = cva(
+  'rounded-xl px-6 py-[18px] transition-colors duration-200 galmuri11-body-m flex-center',
+  {
+    variants: {
+      variant: {
+        red: 'text-white bg-cotam-red-60 hover:bg-cotam-red-70 active:bg-cotam-red-80',
+        blue: 'text-cotam-blue-20 bg-cotam-blue-90 hover:bg-cotam-blue-80 active:bg-cotam-blue-70',
+      },
+    },
+    defaultVariants: {
+      variant: 'red',
+    },
+  },
+);
+
+interface Props
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = forwardRef<HTMLButtonElement, Props>(({ className, variant, ...props }, ref) => {
+  return <button ref={ref} className={cn(buttonVariants({ variant, className }))} {...props} />;
+});
+
+Button.displayName = 'Button';
+export default Button;

--- a/src/components/common/DescriptionCard.tsx
+++ b/src/components/common/DescriptionCard.tsx
@@ -1,0 +1,18 @@
+import { cn } from '@/lib/utils';
+
+interface Props {
+  title: string;
+  contents: string;
+  className?: string;
+}
+
+const DescriptionCard = ({ title, contents, className }: Props) => {
+  return (
+    <div className={cn('flex flex-col gap-1 rounded-xl bg-cotam-blue-95 p-4', className)}>
+      <h2 className="text-cotam-blue-40 galmuri11-body-3">{title}</h2>
+      <p className="text-white galmuri11-body-1">{contents}</p>
+    </div>
+  );
+};
+
+export default DescriptionCard;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,6 +2079,13 @@ chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
+class-variance-authority@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/class-variance-authority/-/class-variance-authority-0.7.0.tgz#1c3134d634d80271b1837452b06d821915954522"
+  integrity sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==
+  dependencies:
+    clsx "2.0.0"
+
 cli-cursor@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
@@ -2107,6 +2114,11 @@ cliui@^8.0.1:
     string-width "^4.2.0"
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
+
+clsx@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.0.0.tgz#12658f3fd98fafe62075595a5c30e43d18f3d00b"
+  integrity sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==
 
 clsx@^2.1.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,6 +2108,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -4845,6 +4850,11 @@ synckit@^0.9.1:
   dependencies:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
+
+tailwind-merge@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.5.2.tgz#000f05a703058f9f9f3829c644235f81d4c08a1f"
+  integrity sha512-kjEBm+pvD+6eAwzJL2Bi+02/9LFLal1Gs61+QB7HvTfQQ0aXwC5LGT8PEt1gS0CWKktKe6ysPTAy3cBC5MeiIg==
 
 tailwindcss@^3.3.0:
   version "3.4.12"


### PR DESCRIPTION
## ❗ Issue Number or Link

- #6 #7 

## 🔎 작업 내용(필수)

- class-variance-authority, clsx, tailwind-merge 패키지 추가
  -  `libs/utils.ts`에 `cn` 메소드 추가 

- Button 컴포넌트 추가
  - variants로 'red', 'blue' 설정, default는 'red'로 지정

- DescriptionCard 컴포넌트 추가
  - 색상 변동이 없는 고정 UI라 별도로 variant 설정을 하지 않았습니다.

## 🖼️ 작업 화면 캡처(선택)

### Button.tsx

예시 코드)
```javascript
<Button className="w-full" variant="blue">
  카카오톡으로 문의하기
</Button>
<Button className="w-full">카카오톡으로 문의하기</Button>
```

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9498fe4b-83a8-49d2-9b47-e486aced9eac">



### DescriptionCard.tsx

예시 코드)
```javascript
<DescriptionCard title="모집기간" contents="상시" />
```

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9cae5395-d97f-48b9-a459-b383c707264e">



## 📢 주의 및 리뷰 요청

- DescriptionCard에 variants 정의가 없는 부분이 통일성에 어긋나나? 싶기도 합니다. 그냥 이대로 가도 될지 의견 부탁드립니다!

## 🔗 Reference

- 해당 테스크를 수행하며 참고한 Link를 모두 작성 (Reference)
