### PR TITLE
Feat: SEO 설정 추가 및 prettier 개행 설정

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "endOfLine": "lf",
+  "insertFinalNewline": true,
   "printWidth": 100,
   "trailingComma": "all",
   "tabWidth": 2,

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
+# 🎯 COTAM - 프론트엔드 모각코 스터디
+
+COTAM은 프론트엔드 개발자들이 함께 모여 성장하는 모각코(모여서 각자 코딩) 스터디입니다.
+1, 3주차는 강남, 2, 4주차는 건대입구에서 진행되며, 함께 고민하고 서로의 성장을 돕는 것을 목표로 합니다.
+
 ## 🎁 코탐 랜딩페이지
 
-### 프론트엔드 팀원
+### 👥 Contributors
 
 <table>
- <tr>
-   <td>
+  <tr>
+    <td>
       <a href="https://github.com/endmoseung">
         <img src="https://avatars.githubusercontent.com/u/103626175?v=4" width="100px" />
       </a>
@@ -21,18 +26,63 @@
     </td>
   </tr>
   <tr>
-    <td align="center"><b><a href="https://github.com/endmoseung">모승</a></b></td>
-    <td align="center"><b><a href="https://github.com/Seongtaek-H">제인</a></b></td>
-    <td align="center"><b><a href="https://github.com/sukyeongh">리안</a></b></td>
+    <td align="center">
+      <b><a href="https://github.com/endmoseung">모승</a></b>
+    </td>
+    <td align="center">
+      <b><a href="https://github.com/Seongtaek-H">제인</a></b>
+    </td>
+    <td align="center">
+      <b><a href="https://github.com/sukyeongh">리안</a></b>
+    </td>
   </tr>
 </table>
 
+### 💻 기술 스택
 
-### 기술 스택
+#### Core
 
-``typescript`` ``NextJS``
+- `typescript`
+- `react 18`, `next 14.1.0`
 
-### 이런걸 신경 썼어요.
-1. 서버사이드와 클라이언트의 분리
-2. 성능
-3. 서로 성장하는 코드리뷰
+#### Styling
+
+- `tailwindcss`
+
+#### Development Environment
+
+- `eslint`, `prettier` - 코드 품질 관리 및 일관된 코드 스타일링
+- `husky`, `lint-staged` - Git Hooks를 통한 코드 품질 자동화
+- `@commitlint` - 일관된 커밋 메시지 컨벤션
+- `@svgr/webpack` - SVG 파일을 React 컴포넌트로 변환
+
+### 🌟 이런걸 신경 썼어요
+
+1. **서버사이드와 클라이언트의 분리**
+
+- Next.js의 서버 컴포넌트를 활용한 효율적인 리소스 관리
+- 적절한 클라이언트/서버 컴포넌트 분리로 성능 최적화
+
+2. **성능**
+
+- 이미지 최적화
+- 컴포넌트 번들 사이즈 최적화
+
+3. **서로 성장하는 코드리뷰**
+
+- 꼼꼼한 PR 리뷰 진행
+- 코드 품질 개선을 위한 토론 문화
+- ESLint, Prettier를 통한 일관된 코드 스타일 유지
+
+### 📝 Scripts
+
+```bash
+# Development
+yarn dev
+
+# Build
+yarn build
+
+# Production
+yarn start
+```

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,9 @@
-import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import './globals.css';
 
 import Header from './_components/Header';
 import Footer from './_components/Footer';
+import { metadata } from './metadata';
 
 const galmuri = localFont({
   src: [
@@ -22,51 +22,7 @@ const galmuri = localFont({
   variable: '--font-galmuri',
 });
 
-export const metadata: Metadata = {
-  title: {
-    template: '%s | COTAM', // 페이지 타이틀 템플릿
-    default: 'COTAM', // 페이지 타이틀이 없을 때 사용될 기본값
-  },
-  description: '열정적으로, 때로는 여유롭게 코탐에서 함께 성장해요.',
-  keywords: [
-    '코탐',
-    '스터디',
-    '코딩 스터디',
-    '모각코',
-    '개발자 네트워킹',
-    '개발 스터디',
-    'cotam',
-    '건대 스터디',
-    '강남 스터디',
-  ],
-
-  metadataBase: new URL('https://cotam.vercel.app'),
-  alternates: {
-    canonical: 'https://cotam.vercel.app/',
-  },
-
-  // Open Graph
-  openGraph: {
-    title: 'COTAM : 다양한 연차의 개발자,디자이너가 함께하고 있는 IT 자기계발 스터디 모임',
-    description: '열정적으로, 때로는 여유롭게 코탐에서 함께 성장해요.',
-    url: 'https://cotam.vercel.app/',
-    siteName: 'Cotam',
-    locale: 'ko_KR',
-    type: 'website',
-  },
-
-  // Twitter
-  twitter: {
-    card: 'summary_large_image',
-    title: 'COTAM : 다양한 연차의 개발자,디자이너가 함께하고 있는 IT 자기계발 스터디 모임',
-    description: '열정적으로, 때로는 여유롭게 코탐에서 함께 성장해요.',
-  },
-
-  robots: {
-    index: true,
-    follow: true,
-  },
-};
+export { metadata };
 
 export default function RootLayout({
   children,

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -1,0 +1,59 @@
+import type { Metadata } from 'next';
+
+import {
+  SITE_DESCRIPTION,
+  SITE_FULL_TITLE,
+  SITE_KEYWORD,
+  SITE_NAME,
+  SITE_URL,
+} from '@/constants/metadata';
+
+export const metadata: Metadata = {
+  title: {
+    template: `%s | ${SITE_NAME}`, // 페이지 타이틀 템플릿
+    default: SITE_NAME, // 페이지 타이틀이 없을 때 사용될 기본값
+  },
+  description: SITE_DESCRIPTION,
+  keywords: SITE_KEYWORD,
+  metadataBase: new URL(SITE_URL),
+  alternates: {
+    canonical: SITE_URL,
+  },
+
+  // Open Graph
+  openGraph: {
+    title: `${SITE_NAME} : ${SITE_FULL_TITLE}`,
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    locale: 'ko_KR',
+    type: 'website',
+  },
+
+  // Twitter
+  twitter: {
+    card: 'summary_large_image',
+    title: `${SITE_NAME} : ${SITE_FULL_TITLE}`,
+    description: SITE_DESCRIPTION,
+  },
+
+  // 검색엔진 인증용
+  verification: {
+    google: '2QYnB8AH6zitSbnBig4hLY1tLLm9Ea-sPqaub6uy2Is',
+  },
+
+  // 추가 메타데이터
+  authors: [{ name: SITE_NAME }],
+  category: 'IT Study',
+
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+};

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,3 +1,4 @@
+import { SITE_URL } from '@/constants/metadata';
 import { MetadataRoute } from 'next';
 
 export default function robots(): MetadataRoute.Robots {
@@ -6,6 +7,7 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: '*',
       allow: '/',
     },
-    host: 'https://cotam.vercel.app/',
+    host: SITE_URL,
+    sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,27 @@
+import { MetadataRoute } from 'next';
+import { SITE_URL } from '@/constants/metadata';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: SITE_URL,
+      lastModified: new Date(),
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/about`,
+      lastModified: new Date(),
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/people`,
+      lastModified: new Date(),
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/recruit`,
+      lastModified: new Date(),
+      priority: 0.9,
+    },
+  ];
+}

--- a/src/constants/metadata.ts
+++ b/src/constants/metadata.ts
@@ -1,0 +1,20 @@
+export const SITE_URL = 'https://cotam.vercel.app' as const;
+export const SITE_NAME = 'COTAM' as const;
+export const SITE_DESCRIPTION = '열정적으로, 때로는 여유롭게 코탐에서 함께 성장해요.' as const;
+export const SITE_KEYWORD = [
+  '프론트엔드',
+  'frontend',
+  '스터디',
+  '개발 스터디',
+  '건대 스터디',
+  '강남 스터디',
+  '코딩 스터디',
+  '프론트엔드 스터디',
+  '모각코',
+  '개발 모각코',
+  '코탐',
+  'cotam',
+  '개발자 네트워킹',
+];
+export const SITE_FULL_TITLE =
+  '다양한 연차의 개발자,디자이너가 함께하고 있는 IT 자기계발 스터디 모임' as const;


### PR DESCRIPTION
## ❗ Issue Number or Link

- N/A

## 🔎 작업 내용(필수)

- 사이트맵(sitemap.xml) 생성 및 설정
- robots.txt 설정 추가
- SEO 메타태그 설정
- Google Search Console 인증 설정
- 메타데이터 상수화 작업
- prettier 설정에 파일별 개행 추가 옵션 설정

## 🔗 Reference
- https://hyeon9mak.github.io/github-no-newline-at-a-end-of-file/
- Next.js Metadata: https://nextjs.org/docs/app/api-reference/functions/generate-metadata
- Next.js Sitemap: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap
